### PR TITLE
Improved filenames

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -227,8 +227,9 @@ Class extension_Content_Type_Mappings extends Extension {
             }
 
             if ($type{0} == '.') {
-                $FileName = $page_data['handle'];
-                Frontend::Page()->addHeaderToPage('Content-Disposition', "attachment; filename={$FileName}{$type}");
+                $page_params = Frontend::Page()->Params();
+                $filename = trim(str_replace('/', '.', $page_params['current-path']), '.');
+                Frontend::Page()->addHeaderToPage('Content-Disposition', "attachment; filename={$filename}{$type}");
             }
         }
     }


### PR DESCRIPTION
We have an export page that return different data based on page parameters. Nevertheless, Content Type Mappings will only use the current page to generate file names. This pull requests utilieses the current path instead, to give the file more context.

Before, the page `export` with the page type `.csv` would have returned `export.csv` independend of the full path. Now, it will return `export.teams.csv` given the path `/export/teams` for example.
